### PR TITLE
Update Azure DevOps CI to trigger only on pull requests

### DIFF
--- a/azure-build.yaml
+++ b/azure-build.yaml
@@ -1,8 +1,3 @@
-trigger:
-  branches:
-    include:
-      - main
-
 pr:
   branches:
     include:


### PR DESCRIPTION
This PR modifies the CI pipeline trigger to restrict builds to pull request events targeting the main branch. 
